### PR TITLE
Prevent `TypeError: Object #<Object> has no method 'signer'` by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
         "name": "Ruben de Vries"
     },
     "description": "A plugin for superagent that signs requests following Joyent's HTTP Signature Scheme",
-    "main": "lib/index.js",
+    "main": "index.js",
     "repository": {
         "type": "git",
         "url": "https://github.com/blocktrail/superagent-http-signature.git"


### PR DESCRIPTION
Running the default code in README.md results in an error:

```
TypeError: Object #<Object> has no method 'signer'
    at sign (/Users/anton/code/sfox/sfox-api/node_modules/superagent-http-signature/lib/index.js:139:27)
    at /Users/anton/code/sfox/sfox-api/node_modules/superagent-http-signature/lib/index.js:153:5
    at Request.use (/Users/anton/code/sfox/sfox-api/node_modules/superagent/lib/node/index.js:688:3)
```

This is because package.json main points to `lib/index.js`, rather than `index.js` which contains the code to set the signer by default if it's not provided. This commit changes main to point to `index.js`. Note that this is the default behavior of npm, however I left it in explicitly so it was clear which `index.js` was being chosen.
