### PR TITLE
Support automatic calc of Content-MD5 header

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -3,6 +3,7 @@
  *
  * rewrite by Ruben de Vries <ruben@blocktrail.com> to work with superagent
  */
+var crypto = require('crypto');
 var sprintf = require('util').format;
 
 function getHeader(request, header) {
@@ -123,6 +124,26 @@ function sign(request, options) {
       value =
         stringToSign +=
           '(request-target): ' + request.method.toLowerCase() + ' ' + pathFromURL(request.url);
+    } else if (h === 'content-md5'){
+      //If request doesn't have a content-md5 header, add one
+      var md5 = getHeader(request, 'content-md5');
+      if (!md5){
+	var hash=crypto.createHash('md5');
+	console.log("DATA:", request._data);
+	//superagent stores content in request._data
+	//But we need to be very careful, it might a string or an object
+	if (request._data){
+	  if (typeof request._data === 'object'){
+	    hash.update(JSON.stringify(request._data));
+	  }else{
+	    hash.update(request._data);
+	  }
+	}
+	md5 = hash.digest('base64');
+	request.set('Content-MD5', md5);
+      }
+      value =
+	stringToSign += 'content-md5: ' + md5;
     } else {
       value = getHeader(request, h);
       if (!value) {


### PR DESCRIPTION
To be really secure, http signing needs to include a Content-MD5 header. While it could be calculated by clients themselves (which the example in the readme assumes is being done), to be really useful it would be nice if this library could do it for you. This PR will add a Content-MD5 header if it is included in the signed header list.
